### PR TITLE
Add PHPUnit dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,8 @@
             "name": "Giorgio Sironi",
             "email": "info@giorgiosironi.com"
         }
-    ]
+    ],
+    "require-dev": {
+        "phpunit/phpunit": "^5|^6|^7"
+    }
 }


### PR DESCRIPTION
Adds the development dependency for PHPUnit 5, 6 or 7. Development dependencies are root-only, so PHPUnit is not installed with the provided example.

After adding the dependency, the example tests can be run as described in the readme.